### PR TITLE
Fix Web Setup Wizard redirect

### DIFF
--- a/magento2/conf.d/extra_protect.conf
+++ b/magento2/conf.d/extra_protect.conf
@@ -1,6 +1,6 @@
 
 # deny all internal locations also default phpmyadmin
-location ~ /(app|bin|var|phpserver|vendor|php[mM]y[aA]dmin|pma)/ { deny all; }
+location ~ /(bin|var|phpserver|vendor|php[mM]y[aA]dmin|pma)/ { deny all; }
 
 # deny access per default .htaccess rules
 location ~ /media/(customer/|downloadable/|import/|theme_customization/.*\.xml) { deny all; }


### PR DESCRIPTION
If I go to System -> Web Setup wizard the redirect returns a nginx Forbidden message.
The url is http://Domain.com/[admin-uri]/admin/backendapp/redirect/app/setup/key/[somekey]

I have tracked it down to the 'extra_protect.conf' where the line:
`location ~ /(app|bin|var|phpserver|vendor|php[mM]y[aA]dmin|pma)/ { deny all; }`
Blocks everything with /app/ in it.

So removing the app| solves the problem.
But this might add extra security risk?