### PR TITLE
ProcessScriptVariables

### DIFF
--- a/magento/conf.d/pagespeed.conf
+++ b/magento/conf.d/pagespeed.conf
@@ -1,6 +1,10 @@
 pagespeed  on;
-pagespeed  FileCachePath  "/var/tmp/";
-pagespeed  LogDir "/var/log/pagespeed";
+#webp is no longer available in Chrome for iOS, breaking thousands of sites. This fixes that.
+set $disable_filters "";
+  if ($http_user_agent ~ CriOS) {
+    set $disable_filters "convert_jpeg_to_webp";
+  }
+pagespeed DisableFilters "$disable_filters";
 
 #to optimize images use: https://github.com/mikebrittain/Wesley
 pagespeed  EnableFilters convert_gif_to_png;

--- a/magento/nginx.conf
+++ b/magento/nginx.conf
@@ -11,6 +11,11 @@ events {
        }
 
 http   {
+    ## Pagespeed module
+    pagespeed  FileCachePath  "/var/tmp/";
+    pagespeed  LogDir "/var/log/pagespeed";
+    pagespeed ProcessScriptVariables on;
+
     index         index.html index.php;
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;

--- a/magento2/conf.d/pagespeed.conf
+++ b/magento2/conf.d/pagespeed.conf
@@ -1,6 +1,4 @@
 pagespeed  on;
-pagespeed  FileCachePath  "/var/tmp/";
-pagespeed  LogDir "/var/log/pagespeed";
 
 #to optimize images use: https://github.com/mikebrittain/Wesley
 pagespeed  EnableFilters convert_gif_to_png;

--- a/magento2/conf.d/pagespeed.conf
+++ b/magento2/conf.d/pagespeed.conf
@@ -1,5 +1,12 @@
 pagespeed  on;
 
+#webp is no longer available in Chrome for iOS, breaking thousands of sites. This fixes that.
+set $disable_filters "";
+  if ($http_user_agent ~ CriOS) {
+    set $disable_filters "convert_jpeg_to_webp";
+  }
+pagespeed DisableFilters "$disable_filters";
+
 #to optimize images use: https://github.com/mikebrittain/Wesley
 pagespeed  EnableFilters convert_gif_to_png;
 pagespeed  EnableFilters insert_image_dimensions;

--- a/magento2/nginx.conf
+++ b/magento2/nginx.conf
@@ -11,6 +11,12 @@ events {
        }
 
 http   {
+
+    ## Pagespeed module
+    pagespeed  FileCachePath  "/var/tmp/";
+    pagespeed  LogDir "/var/log/pagespeed";
+    pagespeed ProcessScriptVariables on;
+
     index         index.html index.php;
     include       /etc/nginx/mime.types;
     types { application/font-woff2  woff2; }


### PR DESCRIPTION
Added the two lines from pagespeed.conf to nginx.conf so that pagespeed ProcessScriptVariables on; could be added as that has to be above the server lines. Also edited pagespeed.conf to include 

      set $disable_filters "";
       if ($http_user_agent ~ CriOS) {
         set $disable_filters "convert_jpeg_to_webp";
       }
       pagespeed DisableFilters "$disable_filters";

which fixes the problem that many sites are facing with pagespeed serving webp (which is not supported) to mobile devices.
