### PR TITLE
fixing m1 installer

### DIFF
--- a/m1_config_install.sh
+++ b/m1_config_install.sh
@@ -2,7 +2,7 @@
 #### Install nginx configuration
 #### IT WILL REMOVE ALL CONFIGURATION FILES THAT HAVE BEEN PREVIOUSLY INSTALLED.
 
-NGINX_EXTRA_CONF="error_page.conf extra_protect.conf export.conf hhvm.conf headers.conf maintenance.conf multishop.conf pagespeed.conf spider.conf"
+NGINX_EXTRA_CONF="error_page.conf extra_protect.conf export.conf hhvm.conf headers.conf maintenance.conf multishop.conf phpmyadmin.conf spider.conf"
 NGINX_EXTRA_CONF_URL="https://raw.githubusercontent.com/magenx/nginx-config/master/magento/conf_m1/"
 
 echo "---> CREATING NGINX CONFIGURATION FILES NOW"

--- a/m1_config_install.sh
+++ b/m1_config_install.sh
@@ -26,7 +26,7 @@ sed -i "s,root /var/www/html,root ${MY_SHOP_PATH},g" /etc/nginx/sites-available/
 ln -s /etc/nginx/sites-available/magento.conf /etc/nginx/sites-enabled/magento.conf
 ln -s /etc/nginx/sites-available/default.conf /etc/nginx/sites-enabled/default.conf
 
-mkdir -p /etc/nginx/conf_m1 cd /etc/nginx/conf_m1/
+mkdir -p /etc/nginx/conf_m1 && cd /etc/nginx/conf_m1/
 for CONFIG in ${NGINX_EXTRA_CONF}
 do
 wget -q ${NGINX_EXTRA_CONF_URL}${CONFIG}


### PR DESCRIPTION
fix missing '&&' after mkdir
`pagespeed.conf` was renamed to `phpmyadmin.conf`