### PR TITLE
Reduce strictness on deny rule

### DIFF
--- a/magento2/sites-available/magento2.conf
+++ b/magento2/sites-available/magento2.conf
@@ -77,7 +77,7 @@ server {
 	include conf_m2/setup.conf;
 	
 	# Deny all internal locations also default phpmyadmin
-	location ~ ^/(app|bin|var|tmp|phpserver|vendor|magento_version|php[mM]y[aA]dmin|pma)/? { deny all; }
+	location ~ ^/(app|bin|var|tmp|phpserver|vendor|magento_version|php[mM]y[aA]dmin|pma)/?$ { deny all; }
 	   
 	location / {
 		try_files $uri $uri/ /index.php$is_args$args;


### PR DESCRIPTION
Category URL's starting with app, var, etc. are blocked by this rule when not having the eol matching character