### PR TITLE
Correction on deny rule

### DIFF
--- a/magento2/sites-available/magento2.conf
+++ b/magento2/sites-available/magento2.conf
@@ -77,7 +77,7 @@ server {
 	include conf_m2/setup.conf;
 	
 	# Deny all internal locations also default phpmyadmin
-	location ~ ^/(app|bin|var|tmp|phpserver|vendor|magento_version|php[mM]y[aA]dmin|pma)/? { deny all; }
+	location ~ ^/(app|bin|var|tmp|phpserver|vendor|magento_version|php[mM]y[aA]dmin|pma)(/([^/]+))*/?$ { deny all; }
 	   
 	location / {
 		try_files $uri $uri/ /index.php$is_args$args;


### PR DESCRIPTION
Realized that this commit was not correct: https://github.com/magenx/Magento-nginx-config/pull/22

Updated now and matches urls like: 

```
/app/
/app/test.html
```

Ignores urls like:
```
/apparel/
/apparel/sunglasses.html
```