### PR TITLE
image filter: too big response

### DIFF
--- a/magento2/conf_m2/assets.conf
+++ b/magento2/conf_m2/assets.conf
@@ -34,6 +34,7 @@
                 image_filter resize $width $height;
                 image_filter_jpeg_quality 65;
 		image_filter_webp_quality 65;
+		image_filter_buffer 5M;
 		
 		try_files $uri $uri/ @media;
         }


### PR DESCRIPTION
Good afternoon,

And a happy new year 2022.

I have met some casualties when I was working on our back-office with high definition pictures,
Nginx return 415 error code HTTP for product images when editing.

When I was checked the error log of Nginx, messages lead me to the directive image filter :

> 2022/01/05 13:59:30 [error] 2137574#2137574: *1241 image filter: too big response: 1479857 while sending response to client

`image_filter_buffer `
#Set the maximum size of the read image buffer, otherwise 415 error will occur. 

I think it will be a good idea to include this one in a comment or leave as it is,

Ilan Parmentier