### PR TITLE
Using Brotli/Gzip with Varnish 6

### DIFF
--- a/magento2/conf_m2/varnish_proxy.conf
+++ b/magento2/conf_m2/varnish_proxy.conf
@@ -1,6 +1,6 @@
 
     proxy_pass  http://127.0.0.1:8081;
-    proxy_set_header Accept-Encoding "";
+#?    proxy_set_header Accept-Encoding "";
 #   proxy_set_header GEOIP_COUNTRY_CODE $geoip_country_code;
     proxy_set_header X-Real-IP $realip_remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -11,6 +11,6 @@
 #   proxy_set_header X-Forwarded-Port 443;
 #   proxy_set_header X-Secure on;
     proxy_http_version 1.1;
-    proxy_set_header Connection "";
+#?    proxy_set_header Connection "";
     proxy_read_timeout 7200s;
     proxy_send_timeout 7200s;


### PR DESCRIPTION
Good afternoon,

Thank you for your work and for kindly submitted your project freely.

I just would like to take some informations from you, why you pass to the Varnish proxy the directives :
```
proxy_set_header Accept-Encoding "";
proxy_set_header Connection "";
```

As you may know, and sure you do, Brotli is more and more supported by recent navigators.
And it has tremendous effect on the compression (15 to 20 points better than GZIP).
When Brotli is supported, the navigator send an Accept-Encoding to "br" otherwise it gracefully send a "gzip" information to the server.

In particular, to make it work with Varnish (standard version), we need to retrieve the br information from the Accept-Encoding header.

And I do know the interest of the two directives below.
It is not included in my research on most config Nginx + Varnish.

Do you see any particular issue who we will encounter if it is commented ?

Brotli is enabled for the compression request (http directive in nginx) but also enable for compressing caching object in Varnish.
And so far, I have some results in term of speed (I did not test in term of load of the CPU though).

I am looking forward for your answer.

Ilan Parmentier