### PR TITLE
Access to backup in Admin lead to a DMS file download

### DIFF
--- a/magento2/conf_m2/extra_protect.conf
+++ b/magento2/conf_m2/extra_protect.conf
@@ -71,7 +71,8 @@ location ~ ^/(index.php/)?ADMIN_PLACEHOLDER {
         location ~ /backup/index {
             return 200 'Backup disabled';
             add_header Content-Type text/plain;  
-        }
+	    default_type text/plain;
+	}
 }
 
 ## Remove "index.php" in url


### PR DESCRIPTION
nginx : 1.25.1

When I try to access to the backup with Firefox 116.0.2 (Mac), navigator try to download a random DMS file extension.

Only when I add default_type text/plain directive to nginx config, page displays correctly.